### PR TITLE
Добавлен возврат транзакционных агрегатов 

### DIFF
--- a/app/controllers/aggr_bills.ts
+++ b/app/controllers/aggr_bills.ts
@@ -1,0 +1,28 @@
+import { Controller, ItemValidator } from "innots";
+import { Context } from "koa";
+import { AggrBillsModel } from "../models/aggr_bills";
+
+const aggrBillsModel = new AggrBillsModel();
+
+export class AggrBillsController extends Controller {
+    public getAggrBills = async (ctx: Context): Promise<void> => {
+        const dateBorders = this.validate(ctx, (validator: ItemValidator) => {
+            return {
+                startDate: this.isValidDate(validator.item("startDate")),
+                endDate: this.isValidDate(validator.item("endDate"))
+            };
+        });
+
+        ctx.body = await aggrBillsModel.getAggrBills(dateBorders.startDate, dateBorders.endDate);
+    }
+
+    private isValidDate(dateString?: string): Date | null {
+        if (dateString) {
+            const date = new Date(dateString);
+            if (!isNaN(date.getTime())) {
+                return date;
+            }
+        }
+        return null;
+    }
+}

--- a/app/controllers/aggr_bills.ts
+++ b/app/controllers/aggr_bills.ts
@@ -4,15 +4,16 @@ import { AggrBillsModel } from "../models/aggr_bills";
 
 const aggrBillsModel = new AggrBillsModel();
 
+const startDateParamName = "startDate";
+const endDateParamName = "endDate";
+
 export class AggrBillsController extends Controller {
     public getAggrBills = async (ctx: Context): Promise<void> => {
-        const dateBorders = this.validate(ctx, (validator: ItemValidator) => {
-            return {
-                startDate: this.isValidDate(validator.item("startDate")),
-                endDate: this.isValidDate(validator.item("endDate"))
+        const params = ctx.request.query;
+        const dateBorders = {
+                startDate: this.isValidDate(params[startDateParamName]),
+                endDate: this.isValidDate(params[endDateParamName])
             };
-        });
-
         ctx.body = await aggrBillsModel.getAggrBills(dateBorders.startDate, dateBorders.endDate);
     }
 

--- a/app/models/aggr_bills.ts
+++ b/app/models/aggr_bills.ts
@@ -1,0 +1,43 @@
+import { pgService } from "../../app";
+
+export interface IAggrBillsBills {
+    idBills: number;
+    billsCount: number;
+    billsAmount: number;
+    bills_paid_count: number;
+    bills_paid_amount: number;
+    bills_add_timestamp: Date;
+}
+
+export class AggrBillsModel {
+
+    private static dateToUnix(dateTime: Date): number {
+        return Math.floor(dateTime.getTime() / 1000);
+    }
+
+    public async getAggrBills(startDate?: Date, endDate?: Date): Promise<Array<IAggrBillsBills>> {
+        let unixStartDate: number;
+        let unixEndDate: number;
+
+        if (!startDate) {
+            unixStartDate = 0;
+        } else {
+            unixStartDate = AggrBillsModel.dateToUnix(startDate);
+        }
+
+        if (!endDate) {
+            endDate = new Date();
+        }
+
+        unixEndDate = AggrBillsModel.dateToUnix(endDate);
+
+        if (unixEndDate < unixStartDate) {
+            [unixEndDate, unixStartDate] = [unixStartDate, unixEndDate];
+        }
+
+        return pgService.getRows(`
+            SELECT * FROM aggr_bills
+            WHERE bills_add_timestamp >= to_timestamp($1) AND bills_add_timestamp <= to_timestamp($2)`,
+            [unixStartDate, unixEndDate]);
+    }
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,13 +1,16 @@
 import * as config from 'config';
 import * as Router from 'koa-router';
+import { AggrBillsController } from "./controllers/aggr_bills";
 import { AuthController } from "./controllers/auth";
 import { Users as UsersController } from './controllers/users';
 
 const router = new Router();
 const users = new UsersController();
 const auth = new AuthController();
+const aggrBills = new AggrBillsController();
 
 const usersProtectedRoute = config.get('appConfig.apiPrefix') + 'users/';
+const aggrBillsProtectedRoute = config.get('appConfig.apiPrefix') + 'aggrBills';
 const authPublicRoute = config.get('appConfig.publicApiPrefix') + 'auth/';
 
 router
@@ -61,6 +64,26 @@ router
      *
      * @apiSuccess {Object} result пользователь.
      */
-    .get(usersProtectedRoute + 'item', users.getItem);
+    .get(usersProtectedRoute + 'item', users.getItem)
+    /**
+     * @api {get} /api/aggrBills
+     * @apiName getAggrBills
+     * @apiGroup AggrBills
+     *
+     * @apiDescription Возвращает записи из таблицы aggr_bills в определенном временном интервале, если какая-то
+     * из границ интервала не передана или не может быть преобразована в формат даты, то вместо неё используется
+     * граничное значение.(Для начала - 01.01.1970T00:00:00, для конца - текущая дата и время)
+     *
+     * @apiHeader (Authorization) authorization Authorization value.
+     * @apiHeaderExample Headers-Example:
+     *   { "Authorization": "Bearer :jwtToken" }
+     *
+     * @apiParam {string} (optional) Начало временного интервала для фильтровки по дате.
+     * @apiParam {string} (optional) Конец временного интервала для фильтровки по дате.
+     * Строки параметров должны конвертироваться в формат Date.
+     *
+     * @apiSuccess {Object} result записи из таблицы.
+     */
+    .get(aggrBillsProtectedRoute, aggrBills.getAggrBills);
 
 export { router };

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -78,8 +78,8 @@ router
      * @apiHeaderExample Headers-Example:
      *   { "Authorization": "Bearer :jwtToken" }
      *
-     * @apiParam {string} (optional) Начало временного интервала для фильтровки по дате.
-     * @apiParam {string} (optional) Конец временного интервала для фильтровки по дате.
+     * @apiParam {string} (optional) startDate Начало временного интервала для фильтровки по дате.
+     * @apiParam {string} (optional) endDate Конец временного интервала для фильтровки по дате.
      * Строки параметров должны конвертироваться в формат Date.
      *
      * @apiSuccess {Object} result записи из таблицы.


### PR DESCRIPTION
Добавленный метод возвращает записи из таблицы aggr_bills в определенном временном интервале (параметры запроса startDate - начало интервала, endDate - конец интервала), если какая-то из границ интервала не передана или не может быть преобразована в формат даты, то вместо неё используется  граничное значение. (Для начала интервала - 01.01.1970T00:00:00, для конца - текущая дата и время). 
Аномалия в базе - длинный хвост после запятой в значениях столбцов bills_amount и bills_paid_amount, появляющийся из-за погрешности при вычислении значений с плавающей точкой (аномалия появилась из-за использования типа данных float8, что не рекомендовано при работе с деньгами)